### PR TITLE
fix: utf-8 reads, cost-only csv/jsonl rows, cross-file copilot dedup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,8 @@ Three logical layers (the class names below live in the files above — `Store` 
   `--copilot-dir`); with it off the source never appears. Export carries tokens but **no
   cost** → token-only backend (**`records_cost=False`**, $0/list-price estimate, same
   nudges). OTEL follows the **GenAI semantic conventions** where one call is logged up to
-  four ways, so `_parse_file` **dedups per file** by trace/response id, keeping the
+  four ways — spans and logs land in *different* files — so `_parse` **dedups across all
+  files** by trace/response id, keeping the
   highest-fidelity record (chat span > inference log > agent-turn log > agent-summary span;
   `_classify`/`_emit`). OpenAI-style tokens (input includes cache read; `cache_write` from
   `cache_creation`; reasoning folded into output; a `total_tokens`-only record back-fills).

--- a/src/opentab/sources.py
+++ b/src/opentab/sources.py
@@ -189,7 +189,7 @@ def _vscode_available(args: argparse.Namespace) -> bool:
                 if not path.endswith((".json", ".jsonl")):
                     continue
                 try:
-                    with open(path, errors="replace") as fh:
+                    with open(path, encoding="utf-8", errors="replace") as fh:
                         for line in fh:
                             if '"promptTokens"' in line or '"completionTokens"' in line:
                                 return True

--- a/src/opentab/stores/copilot.py
+++ b/src/opentab/stores/copilot.py
@@ -308,7 +308,8 @@ class CopilotStore:
     def _files(self) -> list[str]:
         files = glob.glob(os.path.join(self.root_dir, "**", "*.jsonl"), recursive=True)
         # Add the env-var export file, but only if it isn't already one of the globbed
-        # ones -- dedup is per file, so reading the same file twice would double-count.
+        # ones -- the fallback dedup keys are index-based, so reading the same file
+        # twice would double-count records that lack trace/span ids.
         if self._extra_file and os.path.isfile(self._extra_file):
             seen = {os.path.realpath(f) for f in files}
             if os.path.realpath(self._extra_file) not in seen:
@@ -319,40 +320,37 @@ class CopilotStore:
         if self._sessions is not None:
             return self._sessions
         sessions: dict[str, dict] = {}
-        for path, text in read_files_parallel(self._files()):
-            self._parse_file(path, text.split("\n"), sessions)
-        for sid, s in sessions.items():
-            self._finalize(sid, s)
-        # Drop sessions with no recorded usage (non-LLM-only files): they would only add
-        # $0 / 0-token rows to a spend browser.
-        self._sessions = {sid: s for sid, s in sessions.items() if s["model_rows"]}
-        return self._sessions
-
-    def _parse_file(self, path: str, lines: list[str], sessions: dict[str, dict]) -> None:
-        records = [
-            o
-            for line in lines
-            if '"attributes"' in line
-            for o in (self._loads(line),)
-            if isinstance(o, dict) and isinstance(o.get("attributes"), dict)
+        # OTEL exporters write spans and logs to DIFFERENT files, so trace context, the
+        # dedup coverage sets, and the seen keys must span all files: one call logged as
+        # a chat span in file A and an inference log in file B is still one call. Two
+        # passes -- collect every file's candidates first, then emit.
+        per_file = [
+            (path, self._file_records(text.split("\n")))
+            for path, text in read_files_parallel(self._files())
         ]
-        # Per-file trace context: a model / session id seen anywhere on a trace fills in
-        # for records on that trace that omit it.
+        # Cross-file trace context: a model / session id seen anywhere on a trace fills
+        # in for records on that trace that omit it.
         trace_ctx: dict[str, dict] = {}
-        for rec in records:
-            tid = self._trace_id(rec)
-            if not tid:
-                continue
-            attrs = rec["attributes"]
-            ctx = trace_ctx.setdefault(tid, {"model": None, "session": None, "prio": -1})
-            if ctx["model"] is None:
-                ctx["model"] = self._attr_str(attrs, *self._MODEL_ATTRS)
-            sid, prio = self._session_attr(attrs)
-            if sid is not None and prio > ctx["prio"]:
-                ctx["session"], ctx["prio"] = sid, prio
-        candidates = [
-            c for i, rec in enumerate(records) if (c := self._to_candidate(rec, i, trace_ctx, path))
-        ]
+        for _path, records in per_file:
+            for rec in records:
+                tid = self._trace_id(rec)
+                if not tid:
+                    continue
+                attrs = rec["attributes"]
+                ctx = trace_ctx.setdefault(tid, {"model": None, "session": None, "prio": -1})
+                if ctx["model"] is None:
+                    ctx["model"] = self._attr_str(attrs, *self._MODEL_ATTRS)
+                sid, prio = self._session_attr(attrs)
+                if sid is not None and prio > ctx["prio"]:
+                    ctx["session"], ctx["prio"] = sid, prio
+        candidates: list[dict] = []
+        idx = 0  # global running index keeps the fallback dedup keys unique across files
+        for path, records in per_file:
+            for rec in records:
+                c = self._to_candidate(rec, idx, trace_ctx, path)
+                idx += 1
+                if c is not None:
+                    candidates.append(c)
         # Dedup: a chat span is the source of truth; an inference log is dropped when a
         # chat covers its trace/response, an agent-turn log when a chat or inference does,
         # an agent-summary span when any of the three do.
@@ -371,6 +369,22 @@ class CopilotStore:
                 continue
             seen.add(c["dedup_key"])
             self._fold(sessions, c)
+        for sid, s in sessions.items():
+            self._finalize(sid, s)
+        # Drop sessions with no recorded usage (non-LLM-only files): they would only add
+        # $0 / 0-token rows to a spend browser.
+        self._sessions = {sid: s for sid, s in sessions.items() if s["model_rows"]}
+        return self._sessions
+
+    @classmethod
+    def _file_records(cls, lines: list[str]) -> list[dict]:
+        return [
+            o
+            for line in lines
+            if '"attributes"' in line
+            for o in (cls._loads(line),)
+            if isinstance(o, dict) and isinstance(o.get("attributes"), dict)
+        ]
 
     @staticmethod
     def _loads(line: str):

--- a/src/opentab/stores/csv_source.py
+++ b/src/opentab/stores/csv_source.py
@@ -211,7 +211,7 @@ class CsvStore:
         # True iff the CSV has a cost column with any positive value. Cheap pass so it is
         # safe in __init__ (CombinedStore reads records_cost before workflows()).
         try:
-            with open(self.csv_path, newline="", errors="replace") as fh:
+            with open(self.csv_path, newline="", encoding="utf-8", errors="replace") as fh:
                 reader = csv.DictReader(fh)
                 mapping, is_credits = self._resolve_headers(reader.fieldnames)
                 col = mapping.get("cost")
@@ -247,7 +247,7 @@ class CsvStore:
             return self._sessions
         sessions: dict[str, dict] = {}
         try:
-            with open(self.csv_path, newline="", errors="replace") as fh:
+            with open(self.csv_path, newline="", encoding="utf-8", errors="replace") as fh:
                 reader = csv.DictReader(fh)
                 mapping, cost_is_credits = self._resolve_headers(reader.fieldnames)
                 for row in reader:

--- a/src/opentab/stores/csv_source.py
+++ b/src/opentab/stores/csv_source.py
@@ -272,8 +272,13 @@ class CsvStore:
         inp = self._to_int(g("input"))
         out = self._to_int(g("output"))
         cached = self._to_int(g("cached"))
-        if inp == 0 and out == 0 and cached == 0:
-            return  # nothing to attribute (header echo, blank line, metadata-only row)
+        cost = self._to_float(g("cost"))
+        if cost_is_credits:
+            cost *= 0.01
+        # A cost-only row (no token counts) is still real spend; only rows with neither
+        # tokens nor cost are skipped (header echo, blank line, metadata-only row).
+        if inp == 0 and out == 0 and cached == 0 and cost <= 0:
+            return
         ts = self._parse_ts(g("timestamp"))
         project = (g("project") or "").strip()
         sid = (g("session") or "").strip()
@@ -292,9 +297,6 @@ class CsvStore:
                 s["title"] = " ".join(title.split())[:80]
 
         model = self._prefix_model(g("model") or "")
-        cost = self._to_float(g("cost"))
-        if cost_is_credits:
-            cost *= 0.01
         acc = s["models"].get(model)
         if acc is None:
             acc = s["models"][model] = self._new_acc()

--- a/src/opentab/stores/jsonl_source.py
+++ b/src/opentab/stores/jsonl_source.py
@@ -110,7 +110,7 @@ class JsonlStore(CsvStore):
         # True iff any line records a positive cost. Cheap pass, safe in __init__
         # (CombinedStore reads records_cost before workflows()).
         try:
-            with open(self.path, errors="replace") as fh:
+            with open(self.path, encoding="utf-8", errors="replace") as fh:
                 for line in fh:
                     line = line.strip()
                     if not line:
@@ -139,7 +139,7 @@ class JsonlStore(CsvStore):
             return self._sessions
         sessions: dict[str, dict] = {}
         try:
-            with open(self.path, errors="replace") as fh:
+            with open(self.path, encoding="utf-8", errors="replace") as fh:
                 for line in fh:
                     line = line.strip()
                     if not line:

--- a/src/opentab/stores/jsonl_source.py
+++ b/src/opentab/stores/jsonl_source.py
@@ -167,8 +167,11 @@ class JsonlStore(CsvStore):
         inp = self._to_int(self._get(obj, "input"))
         out = self._to_int(self._get(obj, "output"))
         cached = self._to_int(self._get(obj, "cached"))
-        if inp == 0 and out == 0 and cached == 0:
-            return  # nothing to attribute (metadata-only / malformed line)
+        cost = self._row_cost(obj)
+        # A cost-only line (no token counts) is still real spend; only lines with
+        # neither tokens nor cost are skipped (metadata-only / malformed line).
+        if inp == 0 and out == 0 and cached == 0 and cost <= 0:
+            return
         ts = self._parse_ts(self._get(obj, "timestamp"))
         project = str(self._get(obj, "project") or "").strip()
         sid = str(self._get(obj, "session") or "").strip()
@@ -190,7 +193,6 @@ class JsonlStore(CsvStore):
             s["project"] = project
 
         model = self._prefix_model(str(self._get(obj, "model") or ""))
-        cost = self._row_cost(obj)
         acc = s["models"].get(model)
         if acc is None:
             acc = s["models"][model] = self._new_acc()

--- a/src/opentab/stores/openclaw.py
+++ b/src/opentab/stores/openclaw.py
@@ -116,7 +116,7 @@ class OpenClawStore:
         path = os.path.join(self.root_dir, "openclaw.json")
         out: set[str] = set()
         try:
-            with open(path) as fh:
+            with open(path, encoding="utf-8") as fh:
                 data = json.load(fh)
         except (OSError, ValueError):
             return out
@@ -282,7 +282,7 @@ class OpenClawStore:
         # before workflows()). A subscription-only setup -> False (every cost is estimated).
         for path in self._files():
             try:
-                fh = open(path, errors="replace")
+                fh = open(path, encoding="utf-8", errors="replace")
             except OSError:
                 continue
             current_provider = None

--- a/src/opentab/stores/pi.py
+++ b/src/opentab/stores/pi.py
@@ -92,7 +92,7 @@ class PiStore:
         path = os.path.join(os.path.dirname(os.path.normpath(self.root_dir)), "auth.json")
         out: set[str] = set()
         try:
-            with open(path) as fh:
+            with open(path, encoding="utf-8") as fh:
                 data = json.load(fh)
             if isinstance(data, dict):
                 for prov, info in data.items():
@@ -192,7 +192,7 @@ class PiStore:
         # before workflows()). A subscription-only setup -> False (every cost is estimated).
         for path in self._files():
             try:
-                fh = open(path, errors="replace")
+                fh = open(path, encoding="utf-8", errors="replace")
             except OSError:
                 continue
             with fh:

--- a/src/opentab/stores/vscode.py
+++ b/src/opentab/stores/vscode.py
@@ -181,7 +181,9 @@ class VscodeStore:
 
     def _resolve_project(self, hash_dir: str) -> str:
         try:
-            with open(os.path.join(hash_dir, "workspace.json"), errors="replace") as fh:
+            with open(
+                os.path.join(hash_dir, "workspace.json"), encoding="utf-8", errors="replace"
+            ) as fh:
                 meta = json.load(fh)
         except (OSError, ValueError):
             return "(unknown)"

--- a/src/opentab/util.py
+++ b/src/opentab/util.py
@@ -17,7 +17,7 @@ def _read_text(path: str) -> str | None:
     # fh` yields, so a caller that splits on "\n" gets exactly the same lines. Returns
     # None on an unreadable file, which read_files_parallel drops.
     try:
-        with open(path, errors="replace") as fh:
+        with open(path, encoding="utf-8", errors="replace") as fh:
             return fh.read()
     except OSError:
         return None
@@ -278,7 +278,7 @@ def resolve_project_root(directory: str) -> str:
     try:
         dotgit = os.path.join(os.path.expanduser(directory), ".git")
         if os.path.isfile(dotgit):
-            with open(dotgit) as fh:
+            with open(dotgit, encoding="utf-8") as fh:
                 line = fh.read(4096).strip()
             if line.startswith("gitdir:"):
                 gitdir = line[len("gitdir:") :].strip()
@@ -335,7 +335,7 @@ def is_wsl() -> bool:
                 _IS_WSL = True
             else:
                 try:
-                    with open("/proc/version", errors="replace") as fh:
+                    with open("/proc/version", encoding="utf-8", errors="replace") as fh:
                         _IS_WSL = "microsoft" in fh.read().lower()
                 except OSError:
                     _IS_WSL = False
@@ -347,7 +347,7 @@ def wsl_mount_root(conf_path: str = "/etc/wsl.conf") -> str:
     # default /mnt (so C: appears at /mnt/c).
     try:
         section = ""
-        with open(conf_path, errors="replace") as fh:
+        with open(conf_path, encoding="utf-8", errors="replace") as fh:
             for line in fh:
                 for comment in ("#", ";"):
                     line = line.split(comment, 1)[0]

--- a/test_opentab.py
+++ b/test_opentab.py
@@ -6891,6 +6891,38 @@ def test_copilot_store_dedupes_redundant_records_keeping_chat_span():
         assert rows[0]["tokens_total"] == 70
 
 
+def test_copilot_store_dedupes_span_and_log_split_across_files():
+    with tempfile.TemporaryDirectory() as tmp:
+        otel = os.path.join(tmp, ".copilot", "otel")
+        # OTEL exporters write spans and logs to DIFFERENT files: the same call appears
+        # as a chat span in spans.jsonl and an inference log in logs.jsonl. It must
+        # count once (the chat span's 60/10), never twice.
+        chat = _otel_chat(
+            "conv-x", "gpt-5.4", 60, 10, trace="trace-x", span="chat-1", resp="resp-x"
+        )
+        inference = {
+            "traceId": "trace-x",
+            "hrTime": [1775934263, 0],
+            "_body": "GenAI inference: gpt-5.4",
+            "attributes": {
+                "event.name": "gen_ai.client.inference.operation.details",
+                "gen_ai.response.model": "gpt-5.4",
+                "gen_ai.conversation.id": "conv-x",
+                "gen_ai.response.id": "resp-x",
+                "gen_ai.usage.input_tokens": 80,
+                "gen_ai.usage.output_tokens": 20,
+            },
+        }
+        _write_otel(otel, [chat], name="spans.jsonl")
+        _write_otel(otel, [inference], name="logs.jsonl")
+        store = ot.CopilotStore(otel, _copilot_args(otel))
+        rows = [r for r in store.model_breakdown() if r["root_id"] == "conv-x"]
+        assert len(rows) == 1
+        assert rows[0]["runs"] == 1  # the log in the other file was suppressed
+        assert rows[0]["unpriced_input"] == 60 and rows[0]["unpriced_output"] == 10
+        assert rows[0]["tokens_total"] == 70
+
+
 def test_copilot_store_enriches_cwd_and_title_from_session_store_db():
     with tempfile.TemporaryDirectory() as tmp:
         copilot = os.path.join(tmp, ".copilot")

--- a/test_opentab.py
+++ b/test_opentab.py
@@ -6288,6 +6288,29 @@ def test_csv_credits_column_prices_as_real_spend():
         assert row["unpriced_input"] == 0 and row["unpriced_output"] == 0
 
 
+def test_csv_keeps_cost_only_rows_as_real_spend():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "copilot.csv")
+        # A row logging only a cost (no token counts) is still real spend: records_cost
+        # probes True from it, so dropping the row would show a $0 metered source.
+        _write_csv(
+            path,
+            ["timestamp", "model", "input_tokens", "output_tokens", "credits", "session_id"],
+            [
+                ["2026-06-18T10:00:00Z", "gpt-4o", 1000, 100, "", "s1"],
+                ["2026-06-18T11:00:00Z", "claude-opus-4-5", "", "", 75, "s2"],
+                ["2026-06-18T12:00:00Z", "", "", "", "", "s3"],  # truly empty -> skipped
+            ],
+        )
+        store = ot.CsvStore(path, _csv_args())
+        assert store.records_cost is True
+        workflows = store.workflows()
+        assert {w.id for w in workflows} == {"s1", "s2"}  # s3 stays dropped
+        s2 = next(w for w in workflows if w.id == "s2")
+        assert s2.total_cost == round(75 * 0.01, 6)  # credits x $0.01 = $0.75
+        assert s2.total_tokens == 0 and s2.unpriced_tokens == 0
+
+
 def test_csv_tolerates_header_aliases_and_epoch_timestamps():
     with tempfile.TemporaryDirectory() as tmp:
         path = os.path.join(tmp, "copilot.csv")
@@ -6473,6 +6496,39 @@ def test_jsonl_cost_and_credits_price_as_real_spend():
         assert w.unpriced_tokens == 0  # metered rows aren't re-estimated under "$"
         row = store.model_breakdown()[0]
         assert row["unpriced_input"] == 0 and row["unpriced_output"] == 0
+
+
+def test_jsonl_keeps_cost_only_lines_as_real_spend():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "requests.jsonl")
+        # A line logging only a cost (no token counts) is still real spend: records_cost
+        # probes True from it, so dropping the line would show a $0 metered source.
+        _write_jsonl(
+            path,
+            [
+                {
+                    "timestamp": "2026-06-18T10:00:00Z",
+                    "session_id": "s1",
+                    "model": "gpt-4o",
+                    "input_tokens": 100,
+                    "output_tokens": 10,
+                },
+                {
+                    "timestamp": "2026-06-18T11:00:00Z",
+                    "session_id": "s2",
+                    "model": "claude-opus-4-5",
+                    "cost_usd": 0.5,
+                },
+                {"timestamp": "2026-06-18T12:00:00Z", "session_id": "s3"},  # empty -> skipped
+            ],
+        )
+        store = ot.JsonlStore(path, _jsonl_args())
+        assert store.records_cost is True
+        workflows = store.workflows()
+        assert {w.id for w in workflows} == {"s1", "s2"}  # s3 stays dropped
+        s2 = next(w for w in workflows if w.id == "s2")
+        assert s2.total_cost == 0.5
+        assert s2.total_tokens == 0 and s2.unpriced_tokens == 0
 
 
 def test_jsonl_dedupes_request_id_and_synthesizes_sessions():


### PR DESCRIPTION
Three store correctness fixes (separate commits):

- **UTF-8 reads**: every data-file `open()` relied on the locale encoding, so native Windows (cp1252) read transcripts as mojibake and split non-ASCII cwds into separate projects. `encoding="utf-8"` is now pinned on every user-data read (`_read_text` feeding the JSONL backends, csv/jsonl request logs, pi, openclaw, vscode, the availability probe), keeping existing `errors=` handling.
- **Cost-only rows**: a CSV/JSONL row logging only `cost_usd`/credits with no token counts was dropped by the empty-row check — yet `_probe_records_cost` counted it, so the source claimed `records_cost=True` while showing $0. Rows with positive cost are now ingested; genuinely empty rows stay skipped.
- **Copilot cross-file dedup**: the trace context, coverage sets, and seen keys were local to `_parse_file`, but OTEL exporters write spans and logs to different files — one call logged as a chat span in file A and an inference log in file B counted twice. Candidates are now collected across all files, then deduped and emitted at `_parse` scope, preserving the existing record-shape priority.

Tested: 3 new tests (cost-only csv row, cost-only jsonl line, span+log split across two files → one row); suite 307/307, ruff clean.