### PR TITLE
perf: serve records_cost from the warm cache; memoize subagent nodes

### DIFF
--- a/src/opentab/stores/cached.py
+++ b/src/opentab/stores/cached.py
@@ -9,11 +9,12 @@ the 0.8s -> ~50ms warm start. Any change (a file added, edited, or removed) miss
 falls through to a normal parse, then rewrites the cache, so a stale rollup is never
 shown; mtime is nanosecond-grained, so an in-place edit reliably invalidates.
 
-Only workflows() and model_breakdown() are intercepted -- they feed the first frame.
-Everything else (workflow_nodes, tool_breakdown, message_timeline, supports_*, summary,
-records_cost, demo, demo_scale, ...) delegates straight to the wrapped store, which
-parses lazily the first time you actually drill into a session. So a warm start paints
-instantly and only pays the parse if and when you open a session's detail.
+Only workflows(), model_breakdown() and records_cost are intercepted -- they feed the
+first frame (records_cost because some backends can only answer it by reading their
+whole corpus). Everything else (workflow_nodes, tool_breakdown, message_timeline,
+supports_*, summary, demo, demo_scale, ...) delegates straight to the wrapped store,
+which parses lazily the first time you actually drill into a session. So a warm start
+paints instantly and only pays the parse if and when you open a session's detail.
 
 The cache is disabled under --demo (demo never persists, and its per-process scale must
 not be baked in) and --no-cache; sources.make_store applies the wrapper.
@@ -28,7 +29,7 @@ from dataclasses import asdict
 
 from opentab.models import Workflow
 
-CACHE_VERSION = 2  # bump when the cached payload shape changes (invalidates old files)
+CACHE_VERSION = 3  # bump when the cached payload shape changes (invalidates old files)
 
 
 def cache_dir() -> str:
@@ -49,9 +50,20 @@ class CachedStore:
         self.served_from_cache: bool | None = None  # set by workflows(); read by --timings
 
     # Anything not intercepted below is the wrapped store's -- workflow_nodes, the Turns/
-    # Tools extras, supports_*, records_cost, demo, source_name, summary, and so on.
+    # Tools extras, supports_*, demo, source_name, summary, and so on.
     def __getattr__(self, name):
         return getattr(self._store, name)
+
+    @property
+    def records_cost(self) -> bool:
+        # Served from the cache on a fingerprint hit: some backends (pi/OpenClaw/CSV/
+        # JSONL) can only answer this by reading their whole corpus, which would defeat
+        # the warm start. A miss (or a pre-v3 cache) delegates like __getattr__ does.
+        if self._disk is not None and "records_cost" in self._disk:
+            fp = self._live_fp if self._live_fp is not None else self._fingerprint()
+            if self._disk.get("fingerprint") == fp:
+                return bool(self._disk["records_cost"])
+        return getattr(self._store, "records_cost", True)
 
     # --- fingerprint / cache file -------------------------------------------------
     def _fingerprint(self) -> list:
@@ -89,6 +101,9 @@ class CachedStore:
             "version": CACHE_VERSION,
             "source": self._source,
             "fingerprint": fingerprint,
+            # Cheap here: the backend just parsed, so a lazy records_cost derives from
+            # that parse instead of running its full-corpus probe.
+            "records_cost": bool(getattr(self._store, "records_cost", True)),
             "workflows": workflows,
             "model_breakdown": model_breakdown,
         }
@@ -108,9 +123,14 @@ class CachedStore:
         # fingerprint (the common warm start / no-op reload) serves the cache untouched.
         self._live_fp = self._fingerprint()
         if self._disk is not None and self._disk.get("fingerprint") == self._live_fp:
-            self._fresh_wf = None  # a hit: nothing new to write
-            self.served_from_cache = True
-            return [Workflow(**row) for row in self._disk["workflows"]]
+            try:
+                rows = [Workflow(**row) for row in self._disk["workflows"]]
+            except TypeError:
+                self._disk = None  # cached fields drifted from the dataclass: reparse
+            else:
+                self._fresh_wf = None  # a hit: nothing new to write
+                self.served_from_cache = True
+                return rows
         workflows = self._store.workflows()  # miss: real parse
         self._fresh_wf = [asdict(w) for w in workflows]
         self.served_from_cache = False

--- a/src/opentab/stores/combined.py
+++ b/src/opentab/stores/combined.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+from functools import cached_property
 
 from opentab.models import Workflow
 
@@ -45,7 +46,6 @@ class CombinedStore:
 
     def __init__(self, stores: list):
         self.stores = stores
-        self.records_cost = all(getattr(s, "records_cost", True) for s in stores)
         # Combined demo: each backend would otherwise draw its own random hidden scale,
         # which would distort the cross-source ratio (the Sources view lies about the
         # OpenCode-vs-Claude proportion). Share ONE scale across all backends so the
@@ -65,6 +65,13 @@ class CombinedStore:
             getattr(s, "supports_tool_breakdown", False) for s in stores
         )
         self._owner: dict[str, object] = {}
+
+    @cached_property
+    def records_cost(self) -> bool:
+        # AND of the backends (False when any doesn't record cost), evaluated lazily so
+        # building the merged view never forces a backend's full-corpus cost probe --
+        # after workflows() the warm-start cache answers this for free.
+        return all(getattr(s, "records_cost", True) for s in self.stores)
 
     def workflows(self) -> list[Workflow]:
         # Roll up every backend in parallel, then build the id->owner map and merge on

--- a/src/opentab/stores/csv_source.py
+++ b/src/opentab/stores/csv_source.py
@@ -39,7 +39,9 @@ class CsvStore:
     list rates.
     But cost is handled per-row like HermesStore: if the CSV carries a cost_usd/credits
     column with positive values those rows price as real spend, so records_cost is a
-    per-instance attr (True iff any row has a recorded cost), probed cheaply in __init__.
+    per-instance property (True iff any row has a recorded cost), resolved lazily --
+    derived from a parse when one has run, else probed on first read (never in __init__,
+    so the warm-start cache can answer it without touching the file).
 
     Models are mixed-provider, so each id is provider-prefixed (claude->anthropic/,
     gpt|o3->openai/, gemini->google/) for pricing and the Providers rollup. OpenAI-style
@@ -103,7 +105,7 @@ class CsvStore:
         self.demo_scale = 3.0 ** random.uniform(-1.0, 1.0) if self.demo else 1.0
         self._sessions: dict[str, dict] | None = None  # parsed lazily / on reload
         self._git_root_cache: dict[str, str] = {}
-        self.records_cost = self._probe_records_cost()
+        self._records_cost: bool | None = None  # resolved lazily (records_cost property)
 
     # --- header / value parsing ---------------------------------------------
     @classmethod
@@ -207,9 +209,23 @@ class CsvStore:
             return self._git_root(project)
         return project
 
+    @property
+    def records_cost(self) -> bool:
+        # True iff any row records a positive cost. Lazy so construction never reads the
+        # file (the warm-start cache answers a hit without reaching here): after a parse
+        # it derives from the accumulated per-model costs; the full-file probe runs only
+        # when it is read before any parse.
+        if self._sessions is not None:
+            return any(
+                acc["cost"] > 0 for s in self._sessions.values() for acc in s["models"].values()
+            )
+        if self._records_cost is None:
+            self._records_cost = self._probe_records_cost()
+        return self._records_cost
+
     def _probe_records_cost(self) -> bool:
-        # True iff the CSV has a cost column with any positive value. Cheap pass so it is
-        # safe in __init__ (CombinedStore reads records_cost before workflows()).
+        # True iff the CSV has a cost column with any positive value. Early-exits so it
+        # stays cheap.
         try:
             with open(self.csv_path, newline="", encoding="utf-8", errors="replace") as fh:
                 reader = csv.DictReader(fh)

--- a/src/opentab/stores/jsonl_source.py
+++ b/src/opentab/stores/jsonl_source.py
@@ -81,7 +81,7 @@ class JsonlStore(CsvStore):
         self.demo_scale = 3.0 ** random.uniform(-1.0, 1.0) if self.demo else 1.0
         self._sessions: dict[str, dict] | None = None
         self._git_root_cache: dict[str, str] = {}
-        self.records_cost = self._probe_records_cost()
+        self._records_cost: bool | None = None  # resolved lazily (records_cost property)
 
     def cache_inputs(self) -> list[str]:
         # The single JSONL file whose (size, mtime) fingerprints the warm-start cache.
@@ -107,8 +107,8 @@ class JsonlStore(CsvStore):
         return 0.0
 
     def _probe_records_cost(self) -> bool:
-        # True iff any line records a positive cost. Cheap pass, safe in __init__
-        # (CombinedStore reads records_cost before workflows()).
+        # True iff any line records a positive cost. Early-exits so it stays cheap; only
+        # run when records_cost (the lazy CsvStore property) is read before any parse.
         try:
             with open(self.path, encoding="utf-8", errors="replace") as fh:
                 for line in fh:

--- a/src/opentab/stores/openclaw.py
+++ b/src/opentab/stores/openclaw.py
@@ -31,9 +31,10 @@ class OpenClawStore:
     **unpriced** (the "$" view estimates them) while metered messages with a real cost price
     as spend. The two accumulate independently per message, so a session (even one model)
     mixing both routes is split correctly. Cost is therefore mixed, so -- exactly like
-    `CsvStore`/`HermesStore`/`PiStore` -- **`records_cost` is a per-instance attr** (True iff
-    any *metered* message has a cost), set by a cheap early-exit probe in `__init__` so
-    `CombinedStore` can read it before `workflows()`.
+    `CsvStore`/`HermesStore`/`PiStore` -- **`records_cost` is a per-instance property** (True
+    iff any *metered* message has a cost), resolved lazily: derived from a parse when one
+    has run, else by an early-exit probe on first read (never in `__init__`, so construction
+    stays free and the warm-start cache can answer it without touching the files).
 
     Parsing: each session file is newline-delimited JSON,
     and only `type:"message"` records with `message.role == "assistant"` and a `message.usage`
@@ -85,7 +86,7 @@ class OpenClawStore:
         # provider logs in via "oauth" (a consumer plan, subscription) or a static "token"
         # (a metered API key). Read-only; we read only the mode + provider name.
         self._oauth_providers = self._load_oauth_providers()
-        self.records_cost = self._probe_records_cost()
+        self._records_cost: bool | None = None  # resolved lazily (records_cost property)
 
     # --- mixed-provider model ids (mirrors CsvStore) -------------------------
     @staticmethod
@@ -276,10 +277,24 @@ class OpenClawStore:
                 out.append(path)
         return out
 
+    @property
+    def records_cost(self) -> bool:
+        # True iff any *metered* (non-subscription) message records real spend. Lazy so
+        # construction never reads the corpus (the warm-start cache answers a hit without
+        # reaching here): after a parse it derives from the accumulated per-model costs;
+        # the full-file probe runs only when it is read before any parse.
+        if self._sessions is not None:
+            return any(
+                acc["cost"] > 0 for s in self._sessions.values() for acc in s["models"].values()
+            )
+        if self._records_cost is None:
+            self._records_cost = self._probe_records_cost()
+        return self._records_cost
+
     def _probe_records_cost(self) -> bool:
         # True iff any *metered* (non-subscription) assistant message records a positive
-        # cost. Early-exits so it stays cheap (safe in __init__; CombinedStore reads it
-        # before workflows()). A subscription-only setup -> False (every cost is estimated).
+        # cost. Early-exits so it stays cheap. A subscription-only setup -> False (every
+        # cost is estimated).
         for path in self._files():
             try:
                 fh = open(path, encoding="utf-8", errors="replace")

--- a/src/opentab/stores/pi.py
+++ b/src/opentab/stores/pi.py
@@ -31,9 +31,10 @@ class PiStore:
     **unpriced** (the "$" view estimates them), while metered messages with a real cost
     price as spend. The two accumulate independently per message, so a session (even one
     model) mixing both routes is split correctly. Cost is therefore mixed, so -- exactly
-    like `CsvStore`/`HermesStore` -- **`records_cost` is a per-instance attr** (True iff any
-    *metered* message has a cost), set by a cheap early-exit probe in `__init__` so
-    `CombinedStore` can read it before `workflows()`.
+    like `CsvStore`/`HermesStore` -- **`records_cost` is a per-instance property** (True iff
+    any *metered* message has a cost), resolved lazily: derived from a parse when one has
+    run, else by an early-exit probe on first read (never in `__init__`, so construction
+    stays free and the warm-start cache can answer it without touching the files).
 
     Each session file is newline-delimited JSON: a `session` record carries the canonical
     id + **cwd** (so directories fold to the **git root**, no path-decoding the project
@@ -66,7 +67,7 @@ class PiStore:
         # "$" view estimates them -- exactly like HermesStore's billing_mode split. The
         # signal: auth.json marks plan logins as type "oauth"; plus a few provider markers.
         self._oauth_providers = self._load_oauth_providers()
-        self.records_cost = self._probe_records_cost()
+        self._records_cost: bool | None = None  # resolved lazily (records_cost property)
 
     # --- helpers -------------------------------------------------------------
     def _git_root(self, cwd: str) -> str:
@@ -186,10 +187,24 @@ class PiStore:
     def _files(self) -> list[str]:
         return glob.glob(os.path.join(self.root_dir, "**", "*.jsonl"), recursive=True)
 
+    @property
+    def records_cost(self) -> bool:
+        # True iff any *metered* (non-subscription) message records real spend. Lazy so
+        # construction never reads the corpus (the warm-start cache answers a hit without
+        # reaching here): after a parse it derives from the accumulated per-model costs;
+        # the full-file probe runs only when it is read before any parse.
+        if self._sessions is not None:
+            return any(
+                acc["cost"] > 0 for s in self._sessions.values() for acc in s["models"].values()
+            )
+        if self._records_cost is None:
+            self._records_cost = self._probe_records_cost()
+        return self._records_cost
+
     def _probe_records_cost(self) -> bool:
         # True iff any *metered* (non-subscription) assistant message records a positive
-        # cost. Early-exits so it stays cheap (safe in __init__; CombinedStore reads it
-        # before workflows()). A subscription-only setup -> False (every cost is estimated).
+        # cost. Early-exits so it stays cheap. A subscription-only setup -> False (every
+        # cost is estimated).
         for path in self._files():
             try:
                 fh = open(path, encoding="utf-8", errors="replace")

--- a/src/opentab/tui/app.py
+++ b/src/opentab/tui/app.py
@@ -177,6 +177,9 @@ class App:
         # Per-turn timeline (OpenCode + Claude), same lazy/cached-per-session deal as
         # the tool rows above -- a cheap per-session scan, never loaded at startup.
         self._turns_by_session: dict[str, list[dict]] = {}
+        # Subagent tree per session (workflow_nodes: a recursive CTE / backend parse),
+        # same lazy/cached-per-session deal -- the Subagents tab repaints every frame.
+        self._nodes_by_session: dict[str, list[dict]] = {}
         # Active range: custom bounds from CLI take precedence, else a day window
         # (None = all). Default is all time so the Months panel is actually useful.
         self.custom_since = args.since
@@ -1061,6 +1064,18 @@ class App:
             r["cost"] = round(r.get("cost", 0) * k, 4)
         return rows
 
+    def session_node_rows(self, workflow_id: str) -> list[dict]:
+        # Subagent tree for one session, fetched once and cached. The store call is the
+        # heavy bit (a recursive CTE / backend parse) and detail_subagents runs on every
+        # paint, so memoize like session_tool_rows; the store already demo-scales nodes,
+        # and _priced_nodes copies rows before repricing, so the memo stays pristine.
+        cached = self._nodes_by_session.get(workflow_id)
+        if cached is not None:
+            return cached
+        rows = [dict(r) for r in self.store.workflow_nodes(workflow_id)]
+        self._nodes_by_session[workflow_id] = rows
+        return rows
+
     def _snapshot_real_costs(self) -> None:
         # Freshly loaded rows carry only real cost; seed the real/api snapshots so
         # _apply_price_mode is safe even before the (deferred) model scan runs.
@@ -1213,6 +1228,7 @@ class App:
         self._resolve_project_roots()
         self._tool_by_session.clear()
         self._turns_by_session.clear()
+        self._nodes_by_session.clear()
         self._load_model_cache()
         self.zoom_project = None
         self.workflow_index = min(self.workflow_index, max(0, len(self.workflows) - 1))
@@ -1378,6 +1394,7 @@ class App:
         self._models_loaded = False
         self._tool_by_session.clear()
         self._turns_by_session.clear()
+        self._nodes_by_session.clear()
         self._load_model_cache()
         self._invalidate_workflow_cache()
         if restore:
@@ -1779,7 +1796,7 @@ class App:
 
     def _subagents_dataset(self, session: Workflow) -> tuple[str, list[str], list[list]]:
         nodes = self._priced_nodes(
-            [r for r in self.store.workflow_nodes(session.id) if r["depth"] > 0]
+            [r for r in self.session_node_rows(session.id) if r["depth"] > 0]
         )
         header = ["depth", "agent", "model", "cost", "tokens", "title"]
         rows = [

--- a/src/opentab/tui/renderer.py
+++ b/src/opentab/tui/renderer.py
@@ -1768,7 +1768,7 @@ class Renderer:
 
     def detail_subagents(self, workflow: Workflow, width: int) -> list[str]:
         rows = self._priced_nodes(
-            [row for row in self.store.workflow_nodes(workflow.id) if row["depth"] > 0]
+            [row for row in self.session_node_rows(workflow.id) if row["depth"] > 0]
         )
         if not rows:
             return ["# Subagents", "No subagents used in this workflow."]

--- a/test_opentab.py
+++ b/test_opentab.py
@@ -7461,6 +7461,46 @@ def test_records_cost_probe_runs_lazily_not_at_construction():
         assert sub.records_cost is False
 
 
+def test_subagent_nodes_memoized_per_session():
+    def node(workflow_id, depth, agent, title):
+        return {
+            "id": f"{workflow_id}:{depth}",
+            "depth": depth,
+            "agent": agent,
+            "title": title,
+            "created_at": "",
+            "cost": 1.0,
+            "model_name": "anthropic/x",
+            "tokens_input": 1,
+            "tokens_output": 1,
+            "tokens_reasoning": 0,
+            "tokens_cache_read": 0,
+            "tokens_cache_write": 0,
+            "tokens_total": 2,
+        }
+
+    class NodeStore(FakeStore):
+        node_calls = 0
+
+        def workflow_nodes(self, workflow_id):
+            self.node_calls += 1
+            return [node(workflow_id, 0, "-", "root"), node(workflow_id, 1, "task", "sub")]
+
+    args = type("Args", (), {"since": None, "until": None, "days": None})()
+    app = ot.App(NodeStore([workflow("s1", "2026-06-01 12:00:00")]), args)
+    rows1 = app.session_node_rows("s1")
+    rows2 = app.session_node_rows("s1")
+    assert app.store.node_calls == 1  # every repaint after the first is memo-served
+    assert rows1 is rows2 and [r["depth"] for r in rows1] == [0, 1]
+    # The Subagents export dataset reads through the same memo (no new store call).
+    kind, header, rows = app._subagents_dataset(app.loaded[0])
+    assert kind == "subagents" and app.store.node_calls == 1
+    assert [r[0] for r in rows] == [1]  # depth-0 root filtered out, subagent kept
+    # Reload drops the memo -- the underlying data may have changed.
+    app.reload()
+    app.session_node_rows("s1")
+    assert app.store.node_calls == 2
+
 
 def test_wsl_mount_root_and_windows_path_mapping():
     with tempfile.TemporaryDirectory() as tmp:

--- a/test_opentab.py
+++ b/test_opentab.py
@@ -7335,6 +7335,133 @@ def test_cached_store_warm_start_and_invalidation():
                 os.environ["XDG_CONFIG_HOME"] = old_xdg
 
 
+def test_cached_store_serves_records_cost_and_survives_field_drift():
+    with tempfile.TemporaryDirectory() as tmp:
+        old_xdg = os.environ.get("XDG_CONFIG_HOME")
+        os.environ["XDG_CONFIG_HOME"] = os.path.join(tmp, "cfg")  # isolate the cache dir
+        data = os.path.join(tmp, "data.jsonl")
+        with open(data, "w") as fh:
+            fh.write("one\n")
+
+        class Backend:
+            combined = False
+            demo = False
+            source_name = "Fake"
+
+            def __init__(self):
+                self.workflow_calls = 0
+                self.probe_calls = 0
+
+            @property
+            def records_cost(self):
+                self.probe_calls += 1  # stands in for the full-corpus cost probe
+                return True
+
+            def cache_inputs(self):
+                return [data]
+
+            def workflows(self):
+                self.workflow_calls += 1
+                return [workflow("s1", "2026-06-01 12:00:00", cost=2.0, tokens=100)]
+
+            def model_breakdown(self):
+                return [
+                    {"root_id": "s1", "model_name": "anthropic/x", "runs": 1, "tokens_total": 100}
+                ]
+
+        args = type("Args", (), {"demo": False, "no_cache": False})()
+        cid = "fake|" + data
+        try:
+            # Cold: a real parse; the write reads records_cost off the backend (once).
+            b1 = Backend()
+            c1 = ot.CachedStore(b1, cid, args)
+            c1.workflows()
+            c1.model_breakdown()
+            assert b1.probe_calls == 1
+
+            # Warm: records_cost round-trips from the cache -- the backend's probe is
+            # never touched, whether it's read after workflows() or straight away.
+            b2 = Backend()
+            c2 = ot.CachedStore(b2, cid, args)
+            c2.workflows()
+            assert c2.records_cost is True
+            assert b2.probe_calls == 0 and b2.workflow_calls == 0
+            b3 = Backend()
+            assert ot.CachedStore(b3, cid, args).records_cost is True  # fingerprints itself
+            assert b3.probe_calls == 0
+
+            # A cached row that no longer matches the Workflow dataclass (field drift
+            # without a version bump) falls back to a real parse instead of crashing.
+            with open(c1._path) as fh:
+                payload = json.load(fh)
+            payload["workflows"][0]["bogus_field"] = 1
+            with open(c1._path, "w") as fh:
+                json.dump(payload, fh)
+            b4 = Backend()
+            c4 = ot.CachedStore(b4, cid, args)
+            wf4 = c4.workflows()
+            assert b4.workflow_calls == 1 and [w.id for w in wf4] == ["s1"]
+            assert c4.served_from_cache is False
+        finally:
+            if old_xdg is None:
+                os.environ.pop("XDG_CONFIG_HOME", None)
+            else:
+                os.environ["XDG_CONFIG_HOME"] = old_xdg
+
+
+def test_records_cost_probe_runs_lazily_not_at_construction():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "requests.jsonl")
+        _write_jsonl(
+            path,
+            [
+                {
+                    "timestamp": "2026-06-18T10:00:00Z",
+                    "session_id": "s1",
+                    "model": "gpt-4o",
+                    "input_tokens": 100,
+                    "output_tokens": 10,
+                    "cost_usd": 0.05,
+                }
+            ],
+        )
+        calls = []
+        orig = ot.JsonlStore._probe_records_cost
+        ot.JsonlStore._probe_records_cost = lambda self: (calls.append(1), orig(self))[1]
+        try:
+            store = ot.JsonlStore(path, _jsonl_args())
+            assert calls == []  # constructing must not read the file
+            assert store.records_cost is True  # first read probes...
+            assert store.records_cost is True and calls == [1]  # ...and the answer sticks
+
+            # Parsed first (the cold-start order): the answer derives from the parse's
+            # accumulated per-model costs and the probe never runs at all.
+            calls.clear()
+            store2 = ot.JsonlStore(path, _jsonl_args())
+            store2.workflows()
+            assert store2.records_cost is True and calls == []
+        finally:
+            ot.JsonlStore._probe_records_cost = orig
+
+        # pi's parse-derived answer honors the metered/subscription split like the probe:
+        # a codex-plan cost is a list-price estimate, not spend -> records_cost False.
+        root = os.path.join(tmp, "pi-sessions")
+        _pi_write(
+            root,
+            "--proj--",
+            PI_SID,
+            [
+                _pi_session(PI_SID, tmp),
+                _pi_user("hi"),
+                _pi_assistant("openai/gpt-5", 10, 5, cost=0.01, provider="openai-codex"),
+            ],
+        )
+        sub = ot.PiStore(root, _pi_args())
+        sub.workflows()  # parse first: no probe needed
+        assert sub.records_cost is False
+
+
+
 def test_wsl_mount_root_and_windows_path_mapping():
     with tempfile.TemporaryDirectory() as tmp:
         # wsl.conf parsing: [automount] root= wins, comments stripped, missing -> /mnt.


### PR DESCRIPTION
Two performance fixes (separate commits):

- **records_cost vs the warm cache**: pi/OpenClaw/CSV/JSONL probed `records_cost` in their constructors by reading the whole corpus, and `make_store` builds the leaf before `CachedStore` wraps it — so even a 100% cache hit paid a serial full read of every session file (the `"cost"` fast-skip rarely helps pi/openclaw, which write `usage.cost` on most lines). `records_cost` is now a lazy property on those four backends (derived from an already-run parse, probe only as a first-read fallback), persisted in the cache payload (`CACHE_VERSION` 3), and answered by `CachedStore` on a fingerprint hit without touching the leaf. `CombinedStore`'s AND over its backends becomes a `cached_property` for the same reason. Also folded in: a cache-hit row that no longer matches the `Workflow` dataclass falls back to a real parse instead of crashing.
- **Subagent nodes memo**: `detail_subagents` re-ran `store.workflow_nodes` (recursive CTE or backend parse) on every paint of the Subagents tab — every scroll step and every 200ms toast repaint. Rows are now cached per session in `_nodes_by_session`, the `_tool_by_session`/`_turns_by_session` pattern, cleared in the same reload/source-switch places.

Tested: 3 new tests (cache round-trip with a probe-counting fake backend, lazy-probe semantics incl. the metered/subscription split, memo hit/clear behavior); suite 307/307, ruff clean; `--demo --html` smoke-checked.